### PR TITLE
Modifying buld script to use relative path

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SourceDirectory="/media/alexwun/Data_Ext4/Horizon/service-fabric/src/prod"
+SourceDirectory="../src/prod"
 ClangVersion=6.0
 CMakeGenerator="-G Ninja"
 OutputFile="cmake.out"


### PR DESCRIPTION
The source location was hard coded. This change would ensure that it is relative.